### PR TITLE
Support pushing a single key like a token (rather than key-pair user-pwd); make key names a parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 set-tokens.sh
+*.txt
+*.txt.asc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.8.2-alpine
-RUN apk add --no-cache jq libc-dev libffi-dev make curl py-pip python-dev gcc linux-headers && pip install pynacl
+RUN apk add --no-cache bash jq libc-dev libffi-dev make curl py-pip python-dev gcc linux-headers && pip install pynacl
 COPY generate.* /
 ENTRYPOINT [ "/generate.sh" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.8.2-alpine
 RUN apk add --no-cache bash jq libc-dev libffi-dev make curl py-pip python-dev gcc linux-headers && pip install pynacl
-COPY generate.* /
+# also include checkIfSecretExists.sh but don't use it by default (optional entrypoint)
+COPY checkIfSecretExists.* generate.* /
 ENTRYPOINT [ "/generate.sh" ]
-

--- a/README.MD
+++ b/README.MD
@@ -1,22 +1,34 @@
 # Github Secrets generator
 
-Sets QUAY_USERNAME and QUAY_PASSWORD secrets in the given repository:
-
-
-login = QUAY_USERNAME plaintext value
-
-password = QUAY_PASSWORD plaintext value
+Sets a pair of user and password secrets, eg., QUAY_USERNAME and QUAY_PASSWORD, in the given repository:
 
 ### Usage
 
 1. build the image
 
 ```bash
-$ docker build -t github-secrets-generator .
+$ podman build -t github-secrets-generator .
 ```
 
-2. run command
+2. run the command, passing these parameters in order: 
+
+* GITHUB_TOKEN 
+* github-org/github-repo 
+* SECRET_VARIABLE 
+* SECRET_PLAINTEXT_VALUE 
 
 ```bash
-$ docker run --rm -it github-secrets-generator ${GITHUB_TOKEN} github-org/github-repo ${login} ${password}
+$ podman run --rm -it github-secrets-generator ${GITHUB_TOKEN} github-org/github-repo SECRET_USERNAME ${SECRET_PLAINTEXT_VALUE}
+```
+Or, to save a pair of secrets: 
+
+* GITHUB_TOKEN 
+* github-org/github-repo 
+* USERNAME_VARIABLE 
+* USERNAME_PLAINTEXT_VALUE 
+* PASSWORD_VARIABLE 
+* PASSWORD_PLAINTEXT_VALUE
+
+```bash
+$ podman run --rm -it github-secrets-generator ${GITHUB_TOKEN} github-org/github-repo QUAY_USERNAME ${QUAY_USERNAME} QUAY_PASSWORD ${QUAY_PASSWORD}
 ```

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Github Secrets generator
 
-Sets a pair of user and password secrets, eg., QUAY_USERNAME and QUAY_PASSWORD, in the given repository:
+Sets check if a secret is defined in a given github repo, or upload 1 or more secrets to a github repo.
 
 ### Usage
 
@@ -10,7 +10,27 @@ Sets a pair of user and password secrets, eg., QUAY_USERNAME and QUAY_PASSWORD, 
 $ podman build -t github-secrets-generator .
 ```
 
-2. run the command, passing these parameters in order: 
+Or, use `./run.sh`
+
+2. check if a secret already exists in a repo:
+
+```bash
+$ podman run --rm --entrypoint /checkIfSecretExists.sh github-secrets-generator "${GITHUB_TOKEN}" github-org/github-repo MY_SECRET
+```
+
+Or, use `./run.sh`
+
+3. load 1 or more secrets from a file, assuming each line of the file is in the format:
+
+```
+SECRET_VARIABLE1 SECRET_PLAINTEXT_VALUE1
+SECRET_VARIABLE2 SECRET_PLAINTEXT_VALUE2
+...
+```
+
+Use `./run.sh`
+
+4. You can also uplod individual secrets, passing these parameters in order: 
 
 * GITHUB_TOKEN 
 * github-org/github-repo 
@@ -18,7 +38,7 @@ $ podman build -t github-secrets-generator .
 * SECRET_PLAINTEXT_VALUE 
 
 ```bash
-$ podman run --rm -it github-secrets-generator ${GITHUB_TOKEN} github-org/github-repo SECRET_USERNAME ${SECRET_PLAINTEXT_VALUE}
+$ podman run --rm -it github-secrets-generator ${GITHUB_TOKEN} github-org/github-repo SECRET_TOKEN ${SECRET_PLAINTEXT_VALUE}
 ```
 Or, to save a pair of secrets: 
 
@@ -31,38 +51,4 @@ Or, to save a pair of secrets:
 
 ```bash
 $ podman run --rm -it github-secrets-generator ${GITHUB_TOKEN} github-org/github-repo QUAY_USERNAME ${QUAY_USERNAME} QUAY_PASSWORD ${QUAY_PASSWORD}
-```
-
-3. to load a set of secrets from a file, assuming each line of the file is in the format:
-
-```
-SECRET_VARIABLE1 SECRET_PLAINTEXT_VALUE1
-SECRET_VARIABLE2 SECRET_PLAINTEXT_VALUE2
-...
-```
-
-Run this:
-
-```
-uploadSecretsFromFile() 
-{
-    secretfile=$1
-    GH_ORG_REPO=$2
-    if [[ ! $GITHUB_TOKEN ]]; then echo "Must export a valid GITHUB_TOKEN to run this script."; exit 1; fi
-    echo "In github.com/${GH_ORG_REPO}, update:"
-    while IFS= read -r myline
-    do
-        myVAR=${myline% *}
-        myVAL=${myline#* }
-        if [[ $myVAR ]] && [[ $myVAL ]]; then
-            echo "* $myVAR"
-            podman run --rm github-secrets-generator "${GITHUB_TOKEN}" "${GH_ORG_REPO}" "${myVAR}" "${myVAL}"
-        fi
-        unset myVAR
-        unset myVAL
-    done <"$secretfile"
-}
-
-uploadSecretsFromFile secretfile.txt my-org/my-repo
-
 ```

--- a/README.MD
+++ b/README.MD
@@ -32,3 +32,37 @@ Or, to save a pair of secrets:
 ```bash
 $ podman run --rm -it github-secrets-generator ${GITHUB_TOKEN} github-org/github-repo QUAY_USERNAME ${QUAY_USERNAME} QUAY_PASSWORD ${QUAY_PASSWORD}
 ```
+
+3. to load a set of secrets from a file, assuming each line of the file is in the format:
+
+```
+SECRET_VARIABLE1 SECRET_PLAINTEXT_VALUE1
+SECRET_VARIABLE2 SECRET_PLAINTEXT_VALUE2
+...
+```
+
+Run this:
+
+```
+uploadSecretsFromFile() 
+{
+    secretfile=$1
+    GH_ORG_REPO=$2
+    if [[ ! $GITHUB_TOKEN ]]; then echo "Must export a valid GITHUB_TOKEN to run this script."; exit 1; fi
+    echo "In github.com/${GH_ORG_REPO}, update:"
+    while IFS= read -r myline
+    do
+        myVAR=${myline% *}
+        myVAL=${myline#* }
+        if [[ $myVAR ]] && [[ $myVAL ]]; then
+            echo "* $myVAR"
+            podman run --rm github-secrets-generator "${GITHUB_TOKEN}" "${GH_ORG_REPO}" "${myVAR}" "${myVAL}"
+        fi
+        unset myVAR
+        unset myVAL
+    done <"$secretfile"
+}
+
+uploadSecretsFromFile secretfile.txt my-org/my-repo
+
+```

--- a/checkIfSecretExists.sh
+++ b/checkIfSecretExists.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+GITHUB_TOKEN=$1
+GITHUB_REPO=$2
+FIRST_VAR=$3
+
+OUTPUT=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/${GITHUB_REPO}/actions/secrets/public-key)
+# PUBLIC_KEY=$(echo $OUTPUT  | jq -r .key )
+KEY_ID=$(echo $OUTPUT  | jq -r .key_id )
+# echo "KEY_ID is ${KEY_ID}"
+if [ ! $KEY_ID ]; then echo "Error: could not read public key from https://api.github.com/repos/${GITHUB_REPO}/actions/secrets/public-key !"; exit 1; fi
+
+# echo "Fetching tokens for repository ${GITHUB_REPO} using the key ${PUBLIC_KEY}"
+
+echo -n "Number of secrets: "
+curl -sSL -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/${GITHUB_REPO}/actions/secrets | jq '.total_count'
+
+echo "Secret ${FIRST_VAR}:"
+curl -sSL -H "Authorization: token ${GITHUB_TOKEN}"  -X GET -H "Accept: application/vnd.github.v3+json" \
+ https://api.github.com/repos/${GITHUB_REPO}/actions/secrets/${FIRST_VAR}

--- a/generate.py
+++ b/generate.py
@@ -4,8 +4,10 @@ import json
 import sys
 
 key = sys.argv[1]
-login = sys.argv[2]
-password = sys.argv[3]
+# first secret could be a login
+firstSecret = sys.argv[2]
+# second secret could be a password, ot omitted if only using a key/token
+secondSecret = sys.argv[3]
 
 def encrypt(public_key: str, secret_value: str) -> str:
     """Encrypt a Unicode string using the public key."""
@@ -14,13 +16,16 @@ def encrypt(public_key: str, secret_value: str) -> str:
     encrypted = sealed_box.encrypt(secret_value.encode("utf-8"))
     return b64encode(encrypted).decode("utf-8")
 
-encodedLogin = encrypt(key, login)
-encodedPassword = encrypt(key, password)
-
-result = {
-  "login": encodedLogin,
-  "password": encodedPassword
-}
+encodedfirstSecret = encrypt(key, firstSecret)
+if secondSecret:
+  result = {
+    "firstSecret": encodedfirstSecret,
+    "secondSecret": encrypt(key, secondSecret)
+  }
+else:
+  result = {
+    "firstSecret": encodedfirstSecret
+  }
 
 jsonStr = json.dumps(result, indent=2)
 print(jsonStr)

--- a/generate.py
+++ b/generate.py
@@ -7,7 +7,10 @@ key = sys.argv[1]
 # first secret could be a login
 firstSecret = sys.argv[2]
 # second secret could be a password, ot omitted if only using a key/token
-secondSecret = sys.argv[3]
+if len(sys.argv) > 3:
+  secondSecret = sys.argv[3]
+else:
+  secondSecret = ""
 
 def encrypt(public_key: str, secret_value: str) -> str:
     """Encrypt a Unicode string using the public key."""
@@ -17,7 +20,7 @@ def encrypt(public_key: str, secret_value: str) -> str:
     return b64encode(encrypted).decode("utf-8")
 
 encodedfirstSecret = encrypt(key, firstSecret)
-if secondSecret:
+if secondSecret != "":
   result = {
     "firstSecret": encodedfirstSecret,
     "secondSecret": encrypt(key, secondSecret)

--- a/generate.sh
+++ b/generate.sh
@@ -1,26 +1,36 @@
 #!/bin/sh
 GITHUB_TOKEN=$1
 GITHUB_REPO=$2
-LOGIN=$3
-PASSWORD=$4
+# FIRST_VAR could be "QUAY_USERNAME" and FIRST would be the value of that variable
+FIRST_VAR=$3
+FIRST=$4
+# SECOND_VAR could be "QUAY_PASSWORD" and SECOND would be the value of that variable
+# if saving a single secret, omit SECOND_VAR and SECOND value
+SECOND_VAR=$5
+SECOND=$6
 
 OUTPUT=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/${GITHUB_REPO}/actions/secrets/public-key)
 PUBLIC_KEY=$(echo $OUTPUT  | jq -r .key )
 KEY_ID=$(echo $OUTPUT  | jq -r .key_id )
 echo "Generating tokens for repository ${GITHUB_REPO} using the key ${PUBLIC_KEY}"
-ENCRYPT_RESULT=$(python /generate.py ${PUBLIC_KEY} ${LOGIN} ${PASSWORD})
+if [ ${SECOND} ] && [ ${SECOND_VAR} ]; then
+    ENCRYPT_RESULT=$(python /generate.py ${PUBLIC_KEY} ${FIRST} ${SECOND})
+else
+    ENCRYPT_RESULT=$(python /generate.py ${PUBLIC_KEY} ${FIRST})
+fi
 
 #echo ${ENCRYPT_RESULT}
-ENCODED_LOGIN=$(echo ${ENCRYPT_RESULT}  | jq -r .login )
-ENCODED_PASSWORD=$(echo ${ENCRYPT_RESULT}  | jq -r .password )
+ENCODED_FIRSTSECRET=$(echo ${ENCRYPT_RESULT}  | jq -r .firstSecret )
+ENCODED_SECONDSECRET=$(echo ${ENCRYPT_RESULT}  | jq -r .secondSecret )
 
 echo "KEY_ID is ${KEY_ID}"
 
 echo "secrets list [before]:"
 curl -s -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/${GITHUB_REPO}/actions/secrets
 
-curl -H "Authorization: token ${GITHUB_TOKEN}"  -X PUT -H "Content-Type: application/json" -d "{\"encrypted_value\":\"${ENCODED_LOGIN}\",\"key_id\":\"${KEY_ID}\"}" https://api.github.com/repos/${GITHUB_REPO}/actions/secrets/DOCKERHUB_USERNAME
-curl -H "Authorization: token ${GITHUB_TOKEN}"  -X PUT -H "Content-Type: application/json" -d "{\"encrypted_value\":\"${ENCODED_PASSWORD}\",\"key_id\":\"${KEY_ID}\"}" https://api.github.com/repos/${GITHUB_REPO}/actions/secrets/DOCKERHUB_PASSWORD
-
+curl -H "Authorization: token ${GITHUB_TOKEN}"  -X PUT -H "Content-Type: application/json" -d "{\"encrypted_value\":\"${ENCODED_FIRSTSECRET}\",\"key_id\":\"${KEY_ID}\"}" https://api.github.com/repos/${GITHUB_REPO}/actions/secrets/${FIRST_VAR}
+if [ "${ENCODED_SECONDSECRET}" ]; then
+    curl -H "Authorization: token ${GITHUB_TOKEN}"  -X PUT -H "Content-Type: application/json" -d "{\"encrypted_value\":\"${ENCODED_SECONDSECRET}\",\"key_id\":\"${KEY_ID}\"}" https://api.github.com/repos/${GITHUB_REPO}/actions/secrets/${SECOND_VAR}
+fi
 echo "secrets list [after]:"
 curl -s -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/${GITHUB_REPO}/actions/secrets

--- a/generate.sh
+++ b/generate.sh
@@ -12,6 +12,8 @@ SECOND=$6
 OUTPUT=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/${GITHUB_REPO}/actions/secrets/public-key)
 PUBLIC_KEY=$(echo $OUTPUT  | jq -r .key )
 KEY_ID=$(echo $OUTPUT  | jq -r .key_id )
+echo "KEY_ID is ${KEY_ID}"
+
 echo "Generating tokens for repository ${GITHUB_REPO} using the key ${PUBLIC_KEY}"
 if [ ${SECOND} ] && [ ${SECOND_VAR} ]; then
     ENCRYPT_RESULT=$(python /generate.py ${PUBLIC_KEY} ${FIRST} ${SECOND})
@@ -21,9 +23,11 @@ fi
 
 #echo ${ENCRYPT_RESULT}
 ENCODED_FIRSTSECRET=$(echo ${ENCRYPT_RESULT}  | jq -r .firstSecret )
-ENCODED_SECONDSECRET=$(echo ${ENCRYPT_RESULT}  | jq -r .secondSecret )
-
-echo "KEY_ID is ${KEY_ID}"
+if [ ${SECOND} ] && [ ${SECOND_VAR} ]; then
+    ENCODED_SECONDSECRET=$(echo ${ENCRYPT_RESULT}  | jq -r .secondSecret )
+else
+    ENCODED_SECONDSECRET=""
+fi
 
 echo "secrets list [before]:"
 curl -s -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/${GITHUB_REPO}/actions/secrets
@@ -32,5 +36,6 @@ curl -H "Authorization: token ${GITHUB_TOKEN}"  -X PUT -H "Content-Type: applica
 if [ "${ENCODED_SECONDSECRET}" ]; then
     curl -H "Authorization: token ${GITHUB_TOKEN}"  -X PUT -H "Content-Type: application/json" -d "{\"encrypted_value\":\"${ENCODED_SECONDSECRET}\",\"key_id\":\"${KEY_ID}\"}" https://api.github.com/repos/${GITHUB_REPO}/actions/secrets/${SECOND_VAR}
 fi
+
 echo "secrets list [after]:"
 curl -s -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/${GITHUB_REPO}/actions/secrets

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+build_container ()
+{
+    BUILDER=$(command -v podman || true)
+    if [[ ! -x $BUILDER ]]; then
+        BUILDER=$(command -v docker || true)
+        if [[ ! -x $BUILDER ]]; then
+            echo "[ERROR] can't find docker or podman. Abort!"; exit 1
+        fi
+    fi
+    $BUILDER build -t github-secrets-generator .
+}
+
+checkIfSecretExists()
+{
+    GH_ORG_REPO=$1
+    SECRET_TO_CHECK=$2
+    if [[ ! $GITHUB_TOKEN ]]; then echo "Must export a valid GITHUB_TOKEN to run this script."; exit 1; fi
+    if [[ $SECRET_TO_CHECK == "" ]]; then usage; fi
+    echo "In github.com/${GH_ORG_REPO}, fetch:"
+    for myVAR in $SECRET_TO_CHECK; do
+        echo "* $myVAR"
+        podman run --rm --entrypoint /checkIfSecretExists.sh github-secrets-generator "${GITHUB_TOKEN}" "${GH_ORG_REPO}" "${myVAR}"
+    done
+}
+
+uploadSecretsFromFile()
+{
+    GH_ORG_REPO=$1
+    secretfile=$2
+    if [[ ! $GITHUB_TOKEN ]]; then echo "Must export a valid GITHUB_TOKEN to run this script."; exit 1; fi
+    echo "In github.com/${GH_ORG_REPO}, update:"
+    while IFS= read -r myline
+    do
+        myVAR=${myline% *}
+        myVAL=${myline#* }
+        if [[ $myVAR ]] && [[ $myVAL ]]; then
+            echo "* $myVAR"
+            podman run --rm --entrypoint /generate.sh github-secrets-generator "${GITHUB_TOKEN}" "${GH_ORG_REPO}" "${myVAR}" "${myVAL}"
+        fi
+        unset myVAR
+        unset myVAL
+    done <"$secretfile"
+}
+
+usage () {
+    echo "
+To build the github-secrets-generator container (requires podman or docker):
+
+Usage: $0 --build
+Example: $0 --build
+
+To check if a secret already exists in a repo:
+
+Usage: $0 -r [GH org/project] [SECRET_TO_CHECK]
+Example: $0 -r eclipse/che CHE_BOT_GITHUB_TOKEN
+
+To upload 1 or more secrets from a file (one per line):
+
+Usage: $0 -r [GH org/project] -f [SECRET_FILE]
+Example: $0 -r eclipse/che -f mykeys.txt
+
+Plaintext secret file format: one entry per line, key-value separated by a space
+
+KEY1_NAME VALUE1
+KEY2_NAME VALUE2
+  ...
+
+"
+    exit 1
+}
+
+if [[ $# -lt 1 ]]; then usage; exit; fi
+
+DO_BUILD=0
+REPO=""
+SECRETFILE=""
+SECRET_TO_CHECK=""
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    '--build') DO_BUILD=1; shift 1;; 
+    '-r') REPO="$2"; shift 1;; 
+    '-f') SECRETFILE="$2"; shift 1;; 
+    *) SECRET_TO_CHECK="$1"; shift 1;; 
+  esac
+  shift 1
+done
+
+if [[ $DO_BUILD -eq 1 ]]; then build_container; fi
+
+if [[ ! $REPO ]] && [[ $DO_BUILD -eq 0 ]]; then usage; exit; fi
+
+if [[ $SECRETFILE ]]; then
+    uploadSecretsFromFile $REPO $SECRETFILE
+elif [[ $SECRET_TO_CHECK ]]; then
+    checkIfSecretExists $REPO $SECRET_TO_CHECK
+elif [[ $DO_BUILD -eq 0 ]]; then
+    usage
+fi


### PR DESCRIPTION
3 improvements:

* Support pushing a single key like a token (rather than key-pair user-pwd)
* Make key names a parameter, so we can update QUAY_USERNAME or GITHUB_PASSWORD without having to edit the shell script each time
* add instructions for loading a set of secrets from a file, and clean up console output so it's less verbose